### PR TITLE
Remove accessToken from PDF URLs

### DIFF
--- a/src/com/buldreinfo/jersey/jaxb/V2.java
+++ b/src/com/buldreinfo/jersey/jaxb/V2.java
@@ -191,15 +191,15 @@ public class V2 {
 	}
 
 	@Operation(summary = "Get area PDF by id", responses = {@ApiResponse(responseCode = "200", content = {@Content(mediaType = "application/pdf", array = @ArraySchema(schema = @Schema(implementation = Byte.class)))})})
+	@SecurityRequirement(name = "Bearer Authentication")
 	@GET
 	@Path("/areas/pdf")
 	@Produces("application/pdf")
 	public Response getAreasPdf(@Context final HttpServletRequest request,
-			@Parameter(name = "Access token", required = false) @QueryParam("accessToken") String accessToken,
 			@Parameter(name = "Area id", required = true) @QueryParam("id") int id) throws Throwable{
 		try (DbConnection c = ConnectionPoolProvider.startTransaction()) {
 			final Setup setup = MetaHelper.getMeta().getSetup(request);
-			final int authUserId = auth.getUserId(c, request, MetaHelper.getMeta(), accessToken);
+			final int authUserId = getUserId(request);
 			final Meta meta = new Meta(c, setup, authUserId);
 			final Area area = c.getBuldreinfoRepo().getArea(setup, authUserId, id);
 			final Collection<GradeDistribution> gradeDistribution = c.getBuldreinfoRepo().getGradeDistribution(authUserId, setup, area.getId(), 0);
@@ -446,6 +446,7 @@ public class V2 {
 	}
 
 	@Operation(summary = "Get problem PDF by id", responses = {@ApiResponse(responseCode = "200", content = {@Content(mediaType = "application/pdf", array = @ArraySchema(schema = @Schema(implementation = Byte.class)))})})
+	@SecurityRequirement(name = "Bearer Authentication")
 	@GET
 	@Path("/problem/pdf")
 	@Produces("application/pdf")
@@ -454,7 +455,7 @@ public class V2 {
 			@Parameter(name = "Problem id", required = true) @QueryParam("id") int id) throws Throwable{
 		try (DbConnection c = ConnectionPoolProvider.startTransaction()) {
 			final Setup setup = MetaHelper.getMeta().getSetup(request);
-			final int authUserId = auth.getUserId(c, request, MetaHelper.getMeta(), accessToken);
+			final int authUserId = getUserId(request);
 			final Problem problem = c.getBuldreinfoRepo().getProblem(authUserId, setup, id, false);
 			final Area area = c.getBuldreinfoRepo().getArea(setup, authUserId, problem.getAreaId());
 			final Sector sector = c.getBuldreinfoRepo().getSector(authUserId, false, setup, problem.getSectorId());
@@ -664,6 +665,7 @@ public class V2 {
 	}
 
 	@Operation(summary = "Get sector PDF by id", responses = {@ApiResponse(responseCode = "200", content = {@Content(mediaType = "application/pdf", array = @ArraySchema(schema = @Schema(implementation = Byte.class)))})})
+	@SecurityRequirement(name = "Bearer Authentication")
 	@GET
 	@Path("/sectors/pdf")
 	@Produces("application/pdf")
@@ -672,7 +674,7 @@ public class V2 {
 			@Parameter(name = "Sector id", required = true) @QueryParam("id") int id) throws Throwable{
 		try (DbConnection c = ConnectionPoolProvider.startTransaction()) {
 			final Setup setup = MetaHelper.getMeta().getSetup(request);
-			final int authUserId = auth.getUserId(c, request, MetaHelper.getMeta(), accessToken);
+			final int authUserId = getUserId(request);
 			final Meta meta = new Meta(c, setup, authUserId);
 			final Sector sector = c.getBuldreinfoRepo().getSector(authUserId, false, setup, id);
 			final Collection<GradeDistribution> gradeDistribution = c.getBuldreinfoRepo().getGradeDistribution(authUserId, setup, 0, id);


### PR DESCRIPTION
Access tokens and bearer tokens should not be passed as part of the query string. Per the [OAuth RFC]:

> Don't pass bearer tokens in page URLs:  Bearer tokens SHOULD NOT be
> passed in page URLs (for example as query string parameters).
> Instead, bearer tokens SHOULD be passed in HTTP message headers or
> message bodies for which confidentiality measures are taken.
> Browsers, web servers, and other software may not adequately
> secure URLs in the browser history, web server logs, and other
> data structures.  If bearer tokens are passed in page URLs,
> attackers might be able to steal them from the history data, logs,
> or other unsecured locations.

[oauth rfc]:
  https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-bearer-16#section-4.3

This replaces the query parameter with a header. This means that standard HTTP(S) URLs won't work, and will need to be fetched by the app. That limitation could be fixed with cookies, but that takes extra care and shouldn't be done trivially.

Related PR: https://github.com/jossi87/climbing-web/pull/132